### PR TITLE
Events integration

### DIFF
--- a/admin/class-ucf-location-config.php
+++ b/admin/class-ucf-location-config.php
@@ -18,10 +18,11 @@ if ( ! class_exists( 'UCF_Location_Config' ) ) {
 			 * @var array The option default values
 			 */
 			$option_defaults = array(
-				'events_integration'      => true,
+				'events_integration'      => false,
 				'events_base_url'         => 'https://events.ucf.edu',
 				'events_default_feed'     => 'this-week',
-				'events_default_template' => ''
+				'events_default_template' => '',
+				'events_default_limit'    => 3
 			);
 
 		/**
@@ -38,6 +39,7 @@ if ( ! class_exists( 'UCF_Location_Config' ) ) {
 			add_option( self::$options_prefix . 'events_base_url', $defaults['events_base_url'] );
 			add_option( self::$options_prefix . 'events_default_feed', $defaults['events_default_feed'] );
 			add_option( self::$options_prefix . 'events_default_template', $defaults['events_default_template'] );
+			add_option( self::$options_prefix . 'events_default_limit', $defaults['events_default_limit'] );
 		}
 
 		/**
@@ -52,6 +54,7 @@ if ( ! class_exists( 'UCF_Location_Config' ) ) {
 			delete_option( self::$options_prefix . 'events_base_url' );
 			delete_option( self::$options_prefix . 'events_default_feed' );
 			delete_option( self::$options_prefix . 'events_default_template' );
+			delete_option( self::$options_prefix . 'events_default_limit' );
 		}
 
 		/**
@@ -68,7 +71,8 @@ if ( ! class_exists( 'UCF_Location_Config' ) ) {
 				'events_integration'      => get_option( self::$options_prefix . 'events_integration', $defaults['events_integration'] ),
 				'events_base_url'         => get_option( self::$options_prefix . 'events_base_url', $defaults['events_base_url'] ),
 				'events_default_feed'     => get_option( self::$options_prefix . 'events_default_feed', $defaults['events_default_feed'] ),
-				'events_default_template' => get_option( self::$options_prefix . 'events_default_template', $defaults['events_default_template'] )
+				'events_default_template' => get_option( self::$options_prefix . 'events_default_template', $defaults['events_default_template'] ),
+				'events_default_limit'    => get_option( self::$options_prefix . 'events_default_limit', $defaults['events_default_limit'] )
 			);
 
 			$configurable_defaults = self::format_options( $configurable_defaults );
@@ -112,6 +116,9 @@ if ( ! class_exists( 'UCF_Location_Config' ) ) {
 				switch( $key ) {
 					case 'events_integration':
 						$list[$key] = filter_var( $val, FILTER_VALIDATE_BOOLEAN );
+						break;
+					case 'events_default_limit':
+						$list[$key] = filter_var( $val, FILTER_VALIDATE_INT );
 						break;
 					default:
 						break;
@@ -260,6 +267,19 @@ if ( ! class_exists( 'UCF_Location_Config' ) ) {
 						'description' => 'The default layout to use when generating the events list.',
 						'type'        => 'select',
 						'options'     => $layouts
+					)
+				);
+
+				add_settings_field(
+					self::$options_prefix . 'events_default_limit',
+					'Default Event Count',
+					$display_fn,
+					$settings_slug,
+					'ucf_location_events',
+					array(
+						'label_for'   => self::$options_prefix . 'events_default_limit',
+						'description' => 'The default number of events to display.',
+						'type'        => 'number'
 					)
 				);
 

--- a/admin/class-ucf-location-config.php
+++ b/admin/class-ucf-location-config.php
@@ -18,8 +18,10 @@ if ( ! class_exists( 'UCF_Location_Config' ) ) {
 			 * @var array The option default values
 			 */
 			$option_defaults = array(
-				'events_integration' => true,
-				'events_base_url'    => 'https://events.ucf.edu'
+				'events_integration'      => true,
+				'events_base_url'         => 'https://events.ucf.edu',
+				'events_default_feed'     => 'this-week',
+				'events_default_template' => ''
 			);
 
 		/**
@@ -34,6 +36,8 @@ if ( ! class_exists( 'UCF_Location_Config' ) ) {
 
 			add_option( self::$options_prefix . 'events_integration', $defaults['events_integration'] );
 			add_option( self::$options_prefix . 'events_base_url', $defaults['events_base_url'] );
+			add_option( self::$options_prefix . 'events_default_feed', $defaults['events_default_feed'] );
+			add_option( self::$options_prefix . 'events_default_template', $defaults['events_default_template'] );
 		}
 
 		/**
@@ -46,6 +50,8 @@ if ( ! class_exists( 'UCF_Location_Config' ) ) {
 		public static function delete_options() {
 			delete_option( self::$options_prefix . 'events_integration' );
 			delete_option( self::$options_prefix . 'events_base_url' );
+			delete_option( self::$options_prefix . 'events_default_feed' );
+			delete_option( self::$options_prefix . 'events_default_template' );
 		}
 
 		/**
@@ -59,8 +65,10 @@ if ( ! class_exists( 'UCF_Location_Config' ) ) {
 			$defaults = self::$option_defaults;
 
 			$configurable_defaults = array(
-				'events_integration' => get_option( self::$options_prefix . 'events_integration', $defaults['events_integration'] ),
-				'events_base_url'    => get_option( self::$options_prefix . 'events_base_url', $defaults['events_base_url'] )
+				'events_integration'      => get_option( self::$options_prefix . 'events_integration', $defaults['events_integration'] ),
+				'events_base_url'         => get_option( self::$options_prefix . 'events_base_url', $defaults['events_base_url'] ),
+				'events_default_feed'     => get_option( self::$options_prefix . 'events_default_feed', $defaults['events_default_feed'] ),
+				'events_default_template' => get_option( self::$options_prefix . 'events_default_template', $defaults['events_default_template'] )
 			);
 
 			$configurable_defaults = self::format_options( $configurable_defaults );
@@ -159,7 +167,9 @@ if ( ! class_exists( 'UCF_Location_Config' ) ) {
 			$option_name           = self::$options_prefix . $option_name_no_prefix;
 			$defaults              = self::get_option_defaults();
 
-			return get_option( $option_name, $defaults[$option_name_no_prefix] );
+			$default = isset( $defaults[$option_name_no_prefix] ) ? $defaults[$option_name_no_prefix] : null;
+
+			return get_option( $option_name, $default );
 		}
 
 		/**
@@ -188,31 +198,85 @@ if ( ! class_exists( 'UCF_Location_Config' ) ) {
 				$settings_slug
 			);
 
-			add_settings_field(
-				self::$options_prefix . 'events_integration',
-				'Enable Events Integration',
-				$display_fn,
-				$settings_slug,
-				'ucf_location_events',
-				array(
-					'label_for'   => self::$options_prefix . 'events_integration',
-					'description' => 'When checked, the events integration will be active, adding additional fields and functionality for displaying events happening at locations.',
-					'type'        => 'checkbox'
-				)
-			);
+			if ( UCF_Location_Utils::ucf_events_is_active() ) {
+				add_settings_field(
+					self::$options_prefix . 'events_integration',
+					'Enable Events Integration',
+					$display_fn,
+					$settings_slug,
+					'ucf_location_events',
+					array(
+						'label_for'   => self::$options_prefix . 'events_integration',
+						'description' => 'When checked, the events integration will be active, adding additional fields and functionality for displaying events happening at locations.',
+						'type'        => 'checkbox'
+					)
+				);
 
-			add_settings_field(
-				self::$options_prefix . 'events_base_url',
-				'Events Base URL',
-				$display_fn,
-				$settings_slug,
-				'ucf_location_events',
-				array(
-					'label_for'   => self::$options_prefix . 'events_base_url',
-					'description' => 'The base URL of the UCF Events system.',
-					'type'        => 'url'
-				)
-			);
+				add_settings_field(
+					self::$options_prefix . 'events_base_url',
+					'Events Base URL',
+					$display_fn,
+					$settings_slug,
+					'ucf_location_events',
+					array(
+						'label_for'   => self::$options_prefix . 'events_base_url',
+						'description' => 'The base URL of the UCF Events system.',
+						'type'        => 'url'
+					)
+				);
+
+				$feed_options = array(
+					'today'      => 'Today',
+					'this-week'  => 'This Week',
+					'this-month' => 'This Month',
+					'this-year'  => 'This Year',
+					'upcoming'   => 'Upcoming'
+				);
+
+				add_settings_field(
+					self::$options_prefix . 'events_default_feed',
+					'Default Feed',
+					$display_fn,
+					$settings_slug,
+					'ucf_location_events',
+					array(
+						'label_for'   => self::$options_prefix . 'events_default_feed',
+						'description' => 'The default feed to use when fetching events.',
+						'type'        => 'select',
+						'options'     => $feed_options
+					)
+				);
+
+				$layouts = UCF_Events_Config::get_layouts();
+
+				add_settings_field(
+					self::$options_prefix . 'events_default_template',
+					'Default Layout',
+					$display_fn,
+					$settings_slug,
+					'ucf_location_events',
+					array(
+						'label_for'   => self::$options_prefix . 'events_default_template',
+						'description' => 'The default layout to use when generating the events list.',
+						'type'        => 'select',
+						'options'     => $layouts
+					)
+				);
+
+			} else {
+				add_settings_field(
+					null,
+					'Events Integration Requirements',
+					$display_fn,
+					$settings_slug,
+					'ucf_location_events',
+					array(
+						'label_for'   => null,
+						'description' => 'The events integration requires the <a href="" target="blank">UCF Events Plugin</a> to be installed and active.',
+						'type'        => 'message'
+					)
+				);
+			}
 		}
 
 		/**
@@ -270,6 +334,19 @@ if ( ! class_exists( 'UCF_Location_Config' ) ) {
 					endif;
 					$markup = ob_get_clean();
 					break;
+				case 'select':
+					ob_start();
+				?>
+					<select id="<?php echo $option_name; ?>" name="<?php echo $option_name; ?>">
+					<?php foreach( $options as $val => $text ) : ?>
+						<option value="<?php echo $val; ?>"<?php echo ( $val === $current_val ) ? ' selected' : ''; ?>>
+							<?php echo $text; ?>
+						</option>
+					<?php endforeach; ?>
+					</select>
+				<?php
+					$markup = ob_get_clean();
+					break;
 				case 'number':
 				case 'date':
 				case 'email':
@@ -285,6 +362,15 @@ if ( ! class_exists( 'UCF_Location_Config' ) ) {
 					<p class="description">
 						<?php echo $description; ?>
 					</p>
+				<?php
+					$markup = ob_get_clean();
+					break;
+				case 'message':
+					ob_start();
+				?>
+					<div style="background-color: #fff; color: #000; padding: 1rem 2rem; border: 1px solid #acacac;">
+						<p><?php echo $description; ?></p>
+					</div>
 				<?php
 					$markup = ob_get_clean();
 					break;

--- a/includes/class-ucf-location-post-type.php
+++ b/includes/class-ucf-location-post-type.php
@@ -258,11 +258,18 @@ if ( ! class_exists( 'UCF_Location_Post_Type' ) ) {
 		 * @return WP_Post
 		 */
 		public static function location_append_meta( $post ) {
-			$meta = get_post_meta( $post->ID );
+			/**
+			 * We depend on ACF for gettings fields.
+			 * If the function doesn't exist, return the post.
+			 */
+			if ( ! function_exists( 'get_fields' ) ) return $post;
+
+			$meta = get_fields( $post->ID );
 			$post->meta = self::reduce_post_meta( $meta );
 
 			// See if we're integrating with the events plugin.
-			if ( UCF_Location_Config::get_option_or_default( 'events_integration' ) ===  true ) {
+			if ( UCF_Location_Config::get_option_or_default( 'events_integration' ) ===  true
+				&& UCF_Location_Utils::ucf_events_is_active() ) {
 				$base_url         = UCF_Location_Config::get_option_or_default( 'events_base_url' );
 				$default_feed     = UCF_Location_Config::get_option_or_default( 'events_default_feed' );
 				$default_template = UCF_Location_Config::get_option_or_default( 'events_default_template' );

--- a/includes/class-ucf-location-post-type.php
+++ b/includes/class-ucf-location-post-type.php
@@ -248,5 +248,82 @@ if ( ! class_exists( 'UCF_Location_Post_Type' ) ) {
 
 			acf_add_local_field_group( $field_group );
 		}
+
+		/**
+		 * Function that appends meta data onto the
+		 * WP_Post object when it's queried
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @param WP_Post $post The WP Post object
+		 * @return WP_Post
+		 */
+		public static function location_append_meta( $post ) {
+			$meta = get_post_meta( $post->ID );
+			$post->meta = self::reduce_post_meta( $meta );
+
+			// See if we're integrating with the events plugin.
+			if ( UCF_Location_Config::get_option_or_default( 'events_integration' ) ===  true ) {
+				$base_url         = UCF_Location_Config::get_option_or_default( 'events_base_url' );
+				$default_feed     = UCF_Location_Config::get_option_or_default( 'events_default_feed' );
+				$default_template = UCF_Location_Config::get_option_or_default( 'events_default_template' );
+				$default_limit    = UCF_Location_Config::get_option_or_default( 'events_default_limit' );
+
+				$request_url = trailingslashit( $base_url ) . trailingslashit( $default_feed );
+
+				$items = UCF_Events_Feed::get_events( array(
+					'feed_url' => $request_url,
+					'limit'    => $default_limit
+				) );
+
+				$markup = UCF_Events_Common::display_events( $items, $default_template, array(), 'shortcode', '' );
+
+				$post->meta['events_markup'] = $markup;
+			}
+
+			return $post;
+		}
+
+		/**
+		 * Adds meta data to all results returned for
+		 * the location post type
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @param array $posts The array of posts
+		 * @param WP_Query $query The WP_Query object
+		 * @return array
+		 */
+		public static function append_meta_to_results( $posts, $query ) {
+			if ( $query->get( 'post_type' ) === 'location' ) {
+				foreach( $posts as $post ) {
+					$post = self::location_append_meta( $post );
+				}
+			}
+
+			return $posts;
+		}
+
+		/**
+		 * Reduces meta data to single values unless they are an array
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @param array $meta_array The array of metadata to reduce
+		 * @return array
+		 */
+		private static function reduce_post_meta( $meta_array ) {
+			$retval = array();
+
+			foreach( $meta_array as $key => $val ) {
+				// Skip if the key starts with an underscore.
+				if ( substr( $key, 0, 1 ) === '_' ) continue;
+
+				if ( is_array( $val ) && count( $val ) === 1 ) {
+					$retval[$key] = $val[0];
+				} else {
+					$retval[$key] = $val;
+				}
+			}
+
+			return $retval;
+		}
 	}
 }

--- a/includes/class-ucf-location-post-type.php
+++ b/includes/class-ucf-location-post-type.php
@@ -269,13 +269,18 @@ if ( ! class_exists( 'UCF_Location_Post_Type' ) ) {
 
 			// See if we're integrating with the events plugin.
 			if ( UCF_Location_Config::get_option_or_default( 'events_integration' ) ===  true
-				&& UCF_Location_Utils::ucf_events_is_active() ) {
+				&& UCF_Location_Utils::ucf_events_is_active()
+				&& isset( $post->meta['ucf_location_id'] ) ) {
+
 				$base_url         = UCF_Location_Config::get_option_or_default( 'events_base_url' );
 				$default_feed     = UCF_Location_Config::get_option_or_default( 'events_default_feed' );
 				$default_template = UCF_Location_Config::get_option_or_default( 'events_default_template' );
 				$default_limit    = UCF_Location_Config::get_option_or_default( 'events_default_limit' );
+				$params           = '?' . http_build_query( array(
+					'location' => $post->meta['ucf_location_id']
+				) );
 
-				$request_url = trailingslashit( $base_url ) . trailingslashit( $default_feed );
+				$request_url = trailingslashit( $base_url ) . trailingslashit( $default_feed ) . $params;
 
 				$items = UCF_Events_Feed::get_events( array(
 					'feed_url' => $request_url,

--- a/includes/class-ucf-location-utilities.php
+++ b/includes/class-ucf-location-utilities.php
@@ -11,9 +11,10 @@ if ( ! class_exists( 'UCF_Location_Utils' ) ) {
 	 */
 	class UCF_Location_Utils {
 		private static
-			$acf_pro_file_location  = 'advanced-custom-fields-pro/acf.php',
-			$acf_free_file_location = 'advanced-custom-fields/acf.php',
-			$plugin_path            = ABSPATH . 'wp-content/plugins/' ;
+			$acf_pro_file_location    = 'advanced-custom-fields-pro/acf.php',
+			$acf_free_file_location   = 'advanced-custom-fields/acf.php',
+			$ucf_events_file_location = 'UCF-Events-Plugin/ucf-events.php',
+			$plugin_path              = ABSPATH . 'wp-content/plugins/' ;
 
 		/**
 		 * Determines if the Advanced Custom Fields
@@ -33,6 +34,24 @@ if ( ! class_exists( 'UCF_Location_Utils' ) ) {
 
 			if ( is_plugin_active( self::$acf_free_file_location ) ) {
 				$plugin_data = get_plugin_data( self::$plugin_path . self::$acf_free_file_location );
+				if ( self::is_above_version( $plugin_data['Version'], $required_version ) ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		/**
+		* Determines if the UCF Events
+		* plugin is installed and active.
+		* @author Jim Barnes
+		* @since 1.0.0
+		* @param string $required_version The version the plugin must be
+		*/
+		public static function ucf_events_is_active( $required_version='2.0.0' ) {
+			if ( is_plugin_active( self::$ucf_events_file_location ) ) {
+				$plugin_data = get_plugin_data( self::$plugin_path . self::$ucf_events_file_location );
 				if ( self::is_above_version( $plugin_data['Version'], $required_version ) ) {
 					return true;
 				}

--- a/includes/class-ucf-location-utilities.php
+++ b/includes/class-ucf-location-utilities.php
@@ -50,9 +50,15 @@ if ( ! class_exists( 'UCF_Location_Utils' ) ) {
 		* @param string $required_version The version the plugin must be
 		*/
 		public static function ucf_events_is_active( $required_version='2.0.0' ) {
-			if ( is_plugin_active( self::$ucf_events_file_location ) ) {
-				$plugin_data = get_plugin_data( self::$plugin_path . self::$ucf_events_file_location );
-				if ( self::is_above_version( $plugin_data['Version'], $required_version ) ) {
+			if ( function_exists( 'is_plugin_active' ) ) {
+				if ( is_plugin_active( self::$ucf_events_file_location ) ) {
+					$plugin_data = get_plugin_data( self::$plugin_path . self::$ucf_events_file_location );
+					if ( self::is_above_version( $plugin_data['Version'], $required_version ) ) {
+						return true;
+					}
+				}
+			} else {
+				if ( class_exists( 'UCF_Events_Feed' ) ) {
 					return true;
 				}
 			}

--- a/ucf-location-cpt.php
+++ b/ucf-location-cpt.php
@@ -81,6 +81,11 @@ if ( ! function_exists( 'ucf_location_init' ) ) {
 		} else {
 			add_action( 'admin_notices', array( 'UCF_Location_Admin_Notices', 'acf_not_active_notice' ), 10, 0 );
 		}
+
+		// Only append metadata on the front end
+		if ( ! is_admin() ) {
+			add_filter( 'posts_results', array( 'UCF_Location_Post_Type', 'append_meta_to_results' ), 10, 2 );
+		}
 	}
 
 	add_action( 'plugins_loaded', 'ucf_location_init', 10, 0 );


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Location-CPT-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Location-CPT-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
* Adds configuration items for controlling the event feed on the location profiles. 
* Also, adds utility functions for adding the location metadata to the WP_Post object when it is queried on the front end (using `is_admin` to determine if the query is happening on a front end of back end page).
* Adds the events markup to the `meta` field on the returned WP_Post object. This can just be echoed in the template for locations within a theme instead of having to generate it.

**Motivation and Context**
Allows for location-specific event feeds to be easily added to location profiles within a theme.

**How Has This Been Tested?**
Changes are available for review in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
