### PR TITLE
Campus imports

### DIFF
--- a/includes/class-ucf-location-post-type.php
+++ b/includes/class-ucf-location-post-type.php
@@ -11,7 +11,7 @@ if ( ! class_exists( 'UCF_Location_Post_Type' ) ) {
 		 */
 		public static function register_post_type() {
 			$labels = apply_filters(
-				'ucf_location_labels',
+				'ucf_location_label_parts',
 				array(
 					'singular'    => 'Location',
 					'plural'      => 'Locations',
@@ -98,7 +98,8 @@ if ( ! class_exists( 'UCF_Location_Post_Type' ) ) {
 				'ucf_location_taxonomies',
 				array(
 					'category',
-					'post_tag'
+					'post_tag',
+					'location_type'
 				)
 			);
 

--- a/includes/class-ucf-location-type-tax.php
+++ b/includes/class-ucf-location-type-tax.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Taxonomy for storing taxonomy types
+ */
+if ( ! class_exists( 'UCF_Location_Type_Taxonomy' ) ) {
+	class UCF_Location_Type_Taxonomy {
+		/**
+		 * Registers the location_type custom
+		 * taxonomy.
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @return void
+		 */
+		public static function register_taxonomy() {
+			$labels = array(
+				'singular'    => 'Location Type',
+				'plural'      => 'Location Types',
+				'text_domain' => 'ucf_location'
+			);
+
+			$labels = apply_filters( 'ucf_location_type_label_parts', $labels );
+
+			register_taxonomy( 'location_type', array(), self::args( $labels ) );
+		}
+
+		/**
+		 * Returns the default labels
+		 * for the location_type taxonomy.
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @param array $labels The label array
+		 * @return array The label array
+		 */
+		private static function labels( $labels ) {
+			$singular       = $labels['singular'];
+			$singular_lower = strtolower( $singular );
+			$plural         = $labels['plural'];
+			$plural_lower   = strtolower( $plural );
+			$text_domain    = $labels['text_domain'];
+
+			$retval = array(
+				'name'                       => _x( $plural, 'Taxonomy General Name', $text_domain ),
+				'singular_name'              => _x( $singular, 'Taxonomy Singular Name', $text_domain ),
+				'menu_name'                  => __( $plural, $text_domain ),
+				'all_items'                  => __( "All $plural", $text_domain ),
+				'parent_item'                => __( "Parent $singular", $text_domain ),
+				'parent_item_colon'          => __( "Parent $singular:", $text_domain ),
+				'new_item_name'              => __( "New $singular Name", $text_domain ),
+				'add_new_item'               => __( "Add New $singular", $text_domain ),
+				'edit_item'                  => __( "Edit $singular", $text_domain ),
+				'update_item'                => __( "Update $singular", $text_domain ),
+				'view_item'                  => __( "View $singular", $text_domain ),
+				'separate_items_with_commas' => __( "Separate $plural_lower with commas", $text_domain ),
+				'add_or_remove_items'        => __( "Add or remove $plural_lower", $text_domain ),
+				'choose_from_most_used'      => __( "Choose from the most used", $text_domain ),
+				'popular_items'              => __( "Popular $plural", $text_domain ),
+				'search_items'               => __( "Search $plural", $text_domain ),
+				'not_found'                  => __( "Not Found", $text_domain ),
+				'no_terms'                   => __( "No $plural_lower", $text_domain ),
+				'items_list'                 => __( "$plural list", $text_domain ),
+				'items_list_navigation'      => __( "$plural list navigation", $text_domain )
+			);
+
+			$retval = apply_filters( 'ucf_location_type_labels', $retval, $labels );
+
+			return $retval;
+		}
+
+		/**
+		 * Returns the argument array
+		 * @author Jim Barnes
+		 * @since 1.0.0
+		 * @param array $labels The label array
+		 * @return array The argument array
+		 */
+		private static function args( $labels ) {
+			$retval = array(
+				'labels'                => self::labels( $labels ),
+				'hierarchical'          => true,
+				'public'                => true,
+				'show_ui'               => true,
+				'show_admin_column'     => true,
+				'show_in_nav_menus'     => true,
+				'show_tagcloud'         => true,
+				'show_in_rest'          => true,
+				'rest_base'             => 'location_types',
+				'rest_controller_class' => 'WP_REST_Terms_Controller',
+				'rewrite'               => array( 'slug' => 'location-type' )
+			);
+
+			$retval = apply_filters( 'ucf_location_type_args', $retval, $labels );
+
+			return $retval;
+		}
+	}
+}

--- a/includes/class-ucf-location-wp-cli.php
+++ b/includes/class-ucf-location-wp-cli.php
@@ -23,7 +23,7 @@ if ( ! class_exists( 'UCF_Location_Commands' ) ) {
 		 * [--object-types=<object-types>]
 		 * : The type of map objects to import.
 		 * ---
-		 * default: Building,DiningLocation
+		 * default: Building,DiningLocation,Location
 		 * ---
 		 *
 		 * [--media-base=<media-base>]
@@ -49,7 +49,7 @@ if ( ! class_exists( 'UCF_Location_Commands' ) ) {
 										: true;
 			$desired_object_types = isset( $assoc_args['object-types'] )
 										? explode( ',', $assoc_args['object-types'] )
-										: array( 'Building', 'DiningLocation' );
+										: array( 'Building', 'DiningLocation', 'Location' );
 			$media_base           = isset( $assoc_args['media-base'] )
 										? $assoc_args['media-base']
 										: 'https://map.ucf.edu/media/';

--- a/ucf-location-cpt.php
+++ b/ucf-location-cpt.php
@@ -20,6 +20,7 @@ require_once 'admin/class-ucf-location-notices.php';
 
 require_once 'admin/class-ucf-location-config.php';
 require_once 'includes/class-ucf-location-post-type.php';
+require_once 'includes/class-ucf-location-type-tax.php';
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once 'importers/class-ucf-location-importer.php';
@@ -41,6 +42,7 @@ if ( ! function_exists( 'ucf_location_activation' ) ) {
 
 		UCF_Location_Config::add_options();
 		UCF_Location_Post_Type::register_post_type();
+		UCF_Location_Type_Taxonomy::register_taxonomy();
 		flush_rewrite_rules();
 	}
 
@@ -73,6 +75,7 @@ if ( ! function_exists( 'ucf_location_init' ) ) {
 		add_action( 'admin_menu', array( 'UCF_Location_Config', 'add_options_page' ), 10, 0 );
 
 		// Init actions here
+		add_action( 'init', array( 'UCF_Location_Type_Taxonomy', 'register_taxonomy' ), 10, 0 );
 		add_action( 'init', array( 'UCF_Location_Post_Type', 'register_post_type' ), 10, 0 );
 		add_action( 'init', array( 'UCF_Location_Config', 'add_option_formatting_filters' ), 10, 0 );
 


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Location-CPT-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Location-CPT-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds the `Location Type` custom taxonomy. This is in preparation of using a wp cli command to automatically determine which `Location Type: Location` (which is basically our campuses) a building or dining location belongs to.

**Motivation and Context**
The Location objects from map (again these are basically campuses) were added as Location custom post type objects because we need to have profiles for them just like buildings and dining locations, and they should appear in the typeahead results at the bottom of the locations page the same way the other locations do. The plan is to use an ACF field to create the relationship between a Location[Location Type: Location] and various buildings and dining locations.

We can update the "Location" `location_type` term to something else to try to avoid confusion. Maybe "Campus"?

**How Has This Been Tested?**
The locations have been imported into dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
