### PR TITLE
Ensure events_markup post meta is empty when no events are returned

### DIFF
--- a/includes/class-ucf-location-post-type.php
+++ b/includes/class-ucf-location-post-type.php
@@ -392,11 +392,14 @@ if ( ! class_exists( 'UCF_Location_Post_Type' ) ) {
 					'limit'    => $default_limit
 				) );
 
-				$args = array(
-					'title' => null
-				);
+				$markup = '';
+				if ( $items ) {
+					$args = array(
+						'title' => null
+					);
 
-				$markup = UCF_Events_Common::display_events( $items, $default_template, $args, 'shortcode', '' );
+					$markup = UCF_Events_Common::display_events( $items, $default_template, $args, 'shortcode', '' );
+				}
 
 				$post->meta['events_markup'] = $markup;
 			}


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Location-CPT-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Location-CPT-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`UCF_Events_Common::display_events()` will still return empty HTML markup and possibly a "no events found" message (depending on the layout used).  Because of this, we can't determine if events were _actually_ returned by checking if the `events_markup` string is empty.  This PR ensures that the string is actually empty when no events were retrieved in `UCF_Location_Post_Type::location_append_meta()`, making it easier to hide missing events content in post templates.

Related: https://github.com/UCF/Main-Site-Theme/issues/202

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
