### PR TITLE
Importer error handling improvements

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: ucfwebcom
 Requires at least: 5.0.0
 Tested up to: 5.3
 Stable tag: 0.1.3
-Requires PHP: 5.6
+Requires PHP: 7.0
 License: GPLv3 or later
 License URI: http://www.gnu.org/copyleft/gpl-3.0.html
 

--- a/importers/class-ucf-location-importer.php
+++ b/importers/class-ucf-location-importer.php
@@ -143,6 +143,11 @@ Errors:
 		 */
 		public function import() {
 			$this->get_data();
+
+			if ( ! $this->map_data ) {
+				return 'Error: Could not retrieve map data.';
+			}
+
 			$this->get_existing();
 			$this->save_data();
 			$this->remove_stale_locations();

--- a/importers/class-ucf-location-importer.php
+++ b/importers/class-ucf-location-importer.php
@@ -128,8 +128,7 @@ Errors:
 
 				foreach( $errors as $error ) {
 					$retval .= "
-	$error->name: $error->message
-					";
+	" . $error['name'] . " : " . $error['message'];
 				}
 			}
 
@@ -236,14 +235,13 @@ Errors:
 
 					if ( $updated === true ) {
 						$this->updated_locations++;
+						unset( $this->existing_locations[$data->id] );
 					} else {
 						$this->errors[] = array(
-							'name'    => $data->name,
+							'name'    => 'Map Location ID ' . $data->id . ' (' . ( $data->name ?? 'name n/a' ) . ')',
 							'message' => $updated->get_error_message()
 						);
 					}
-
-					unset( $this->existing_locations[$data->id] );
 				} else {
 					$created = $this->create_new( $data );
 
@@ -251,8 +249,8 @@ Errors:
 						$this->created_locations++;
 					} else {
 						$this->errors[] = array(
-							'name'    => $data->name,
-							'message' => $updated->get_error_message()
+							'name'    => 'Map Location ID ' . $data->id . ' (' . ( $data->name ?? 'name n/a' ) . ')',
+							'message' => $created->get_error_message()
 						);
 					}
 				}
@@ -276,7 +274,16 @@ Errors:
 		 * @return bool|WP_Error True if updated, the WP_Error if there was an error
 		 */
 		private function update_existing( $post_id, $data ) {
-			$title = isset( $data->name ) ? trim( $data->name ) : trim( $data->title );
+			// Require a name/title for the location.
+			// Bail out early if one isn't available for some reason.
+			$title = isset( $data->name ) ? trim( $data->name ) : '';
+			if ( ! $title && isset( $data->title ) ) {
+				$title = trim( $data->title );
+			}
+			if ( ! $title ) {
+				return new WP_Error( 'ucflocation_map_location_nameless', 'Map location has no name.' );
+			}
+
 			$desc  = isset( $data->profile ) ? trim( $data->profile ) : $data->description;
 
 			$split = explode( '/', untrailingslashit( $data->profile_link ) );
@@ -314,7 +321,16 @@ Errors:
 		 * @return bool|WP_Error True if created, a WP_Error if there was an error
 		 */
 		private function create_new( $data ) {
-			$title = isset( $data->name ) ? trim( $data->name ) : trim( $data->title );
+			// Require a name/title for the location.
+			// Bail out early if one isn't available for some reason.
+			$title = isset( $data->name ) ? trim( $data->name ) : '';
+			if ( ! $title && isset( $data->title ) ) {
+				$title = trim( $data->title );
+			}
+			if ( ! $title ) {
+				return new WP_Error( 'ucflocation_map_location_nameless', 'Map location has no name.' );
+			}
+
 			$desc  = isset( $data->profile ) ? trim( $data->profile ) : $data->description;
 			$split = explode( '/', untrailingslashit( $data->profile_link ) );
 			$post_name = $this->clean_post_name( end( $split ), $data );

--- a/importers/class-ucf-location-importer.php
+++ b/importers/class-ucf-location-importer.php
@@ -143,11 +143,6 @@ Errors:
 		 */
 		public function import() {
 			$this->get_data();
-
-			if ( ! $this->map_data ) {
-				return 'Error: Could not retrieve map data.';
-			}
-
 			$this->get_existing();
 			$this->save_data();
 			$this->remove_stale_locations();
@@ -163,7 +158,7 @@ Errors:
 		private function get_data() {
 			$response      = wp_remote_get( $this->endpoint, array( 'timeout' => 10 ) );
 			$response_code = wp_remote_retrieve_response_code( $response );
-			$result        = false;
+			$result        = array();
 
 			if ( is_array( $response ) && is_int( $response_code ) && $response_code < 400 ) {
 				$result = json_decode( wp_remote_retrieve_body( $response ) );


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Location-CPT-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Location-CPT-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Updated the location importer's `create_new()` and `update_existing()` methods to require incoming location data to have a title/name set.  If the incoming location doesn't have a name/title, processing of that location is skipped and an error is stored + spat out when the import finishes.
- Moved the step that unsets an existing location post from `existing_locations` to only occur when an existing location is successfully updated.
- Fixed errors caused by attempting to loop through `map_data` when `get_data()` returns `false`.
- Fixed output of error messages at the bottom of `print_stats()`
- Bumped minimum PHP version requirement to 7.0 to support null coalescing.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures the locations import fails gracefully when it does run into issues.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
