### PR TITLE
Location import and association scripts - case-insensitive object type matching

### DIFF
--- a/importers/class-ucf-location-associate.php
+++ b/importers/class-ucf-location-associate.php
@@ -26,12 +26,12 @@ if ( ! class_exists( 'UCF_Location_Associate' ) ) {
 			 * @var array The location types that will
 			 * be used as parent locations
 			 */
-			$parent_location_types = array( 'Location' ),
+			$parent_location_types = array( 'location' ),
 			/**
 			 * @var array The location types that will
 			 * be checked for association
 			 */
-			$children_location_types = array( 'Building', 'DiningLocation' ),
+			$children_location_types = array( 'building', 'dininglocation' ),
 			/**
 			 * @var bool When true, children locations
 			 * can be assigned to multiple parents
@@ -59,7 +59,7 @@ if ( ! class_exists( 'UCF_Location_Associate' ) ) {
 		 * @param array $children The location types to be checked
 		 * @param bool $multi_assoc When true, children locations can belong to multiple parent locations.
 		 */
-		public function __construct( $field = 'ucf_location_campus', $distance = 5, $parents = array( 'Location' ), $children = array( 'Building', 'DiningLocation' ), $multi_assoc = false ) {
+		public function __construct( $field = 'ucf_location_campus', $distance = 5, $parents = array( 'location' ), $children = array( 'building', 'dininglocation' ), $multi_assoc = false ) {
 			$this->field                   = $field;
 			$this->distance                = $distance;
 			$this->parent_location_types   = $parents;
@@ -107,8 +107,8 @@ Locations mapped: $this->mapped_locations
 				'tax_query' => array(
 					array(
 						'taxonomy' => 'location_type',
-						'terms'    => $terms,
-						'field'    => 'name',
+						'terms'    => array_map( 'sanitize_title', $terms ),
+						'field'    => 'slug',
 						'operator' => 'IN'
 					)
 				)

--- a/importers/class-ucf-location-importer.php
+++ b/importers/class-ucf-location-importer.php
@@ -433,7 +433,7 @@ Errors:
 			$term = null;
 
 			if ( term_exists( $object_type, 'location_type' ) ) {
-				$term = get_term_by( 'name', $object_type, 'location_type' );
+				$term = get_term_by( 'slug', sanitize_title( $object_type ), 'location_type' );
 				$term = $term->term_id;
 			} else {
 				$term = wp_insert_term( $object_type, 'location_type' );

--- a/importers/class-ucf-location-importer.php
+++ b/importers/class-ucf-location-importer.php
@@ -84,9 +84,9 @@ if ( ! class_exists( 'UCF_Location_Importer' ) ) {
 			$this->desired_object_types = ! empty( $desired_object_types )
 											? $desired_object_types
 											: array(
-												'Building',
-												'DiningLocation',
-												'Location'
+												'building',
+												'dininglocation',
+												'location'
 											);
 			$this->upload_dir = wp_upload_dir();
 			$this->media_base = trailingslashit( $media_base );
@@ -205,7 +205,7 @@ Errors:
 
 			foreach( $results as $result ) {
 				// If this isn't an object type we want, skip it!
-				if ( ! in_array( $result->object_type, $this->desired_object_types ) ) continue;
+				if ( ! in_array( strtolower( $result->object_type ), array_map( 'strtolower', $this->desired_object_types ) ) ) continue;
 
 				$retval[] = $result;
 			}

--- a/includes/class-ucf-location-wp-cli.php
+++ b/includes/class-ucf-location-wp-cli.php
@@ -23,7 +23,7 @@ if ( ! class_exists( 'UCF_Location_Commands' ) ) {
 		 * [--object-types=<object-types>]
 		 * : The type of map objects to import.
 		 * ---
-		 * default: Building,DiningLocation,Location
+		 * default: building,dininglocation,location
 		 * ---
 		 *
 		 * [--media-base=<media-base>]
@@ -83,13 +83,13 @@ if ( ! class_exists( 'UCF_Location_Commands' ) ) {
 		 * [--parent-types=<parent-types>]
 		 * : The location type of the parent locations
 		 * ---
-		 * default: Location
+		 * default: location
 		 * ---
 		 *
 		 * [--child-type=<child-types>]
 		 * : The location type of the children locations
 		 * ---
-		 * default: Building,DiningLocation
+		 * default: building,dininglocation
 		 * ---
 		 *
 		 * [--distance=<distance>]

--- a/includes/class-ucf-location-wp-cli.php
+++ b/includes/class-ucf-location-wp-cli.php
@@ -49,7 +49,7 @@ if ( ! class_exists( 'UCF_Location_Commands' ) ) {
 										: true;
 			$desired_object_types = isset( $assoc_args['object-types'] )
 										? explode( ',', $assoc_args['object-types'] )
-										: array( 'Building', 'DiningLocation', 'Location' );
+										: array( 'building', 'dininglocation', 'location' );
 			$media_base           = isset( $assoc_args['media-base'] )
 										? $assoc_args['media-base']
 										: 'https://map.ucf.edu/media/';
@@ -119,11 +119,11 @@ if ( ! class_exists( 'UCF_Location_Commands' ) ) {
 
 			$parent_types = isset( $assoc_args['parent-types'] ) ?
 							explode( ',', $assoc_args['parent-types'] ) :
-							array( 'Location' );
+							array( 'location' );
 
 			$child_types  = isset( $assoc_args['child-types'] ) ?
 							explode( ',', $assoc_args['child-types'] ) :
-							array( 'Building', 'DiningLocation' );
+							array( 'building', 'dininglocation' );
 
 			$distance     = isset( $assoc_args['distance'] ) ?
 							$assoc_args['distance'] :


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Location-CPT-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Location-CPT-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Updates the location importer and location association scripts to match object types by slug/all lowercase values instead of by term name.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To ensure case-insensitive object type matches are performed for compatibility with upcoming changes to Map, while still being compatible with the current version of Map; resolves #28 

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
