### PR TITLE
Image import fix

### DIFF
--- a/importers/class-ucf-location-importer.php
+++ b/importers/class-ucf-location-importer.php
@@ -534,6 +534,10 @@ Errors:
 		private function upload_media( $image_url, $post_id ) {
 			$existing_thumbnail = get_the_post_thumbnail_url( $post_id );
 
+			/**
+			 * Spend a little time getting the filename of the existing
+			 * thumbnail and the incoming filename so we can compare.
+			 */
 			$image_filename = '';
 			$existing_filename = '';
 
@@ -547,6 +551,11 @@ Errors:
 				$image_filename = isset( $parts['path'] ) ? basename( $parts['path'] ) : '';
 			}
 
+			/**
+			 * If the existing filename and the incoming
+			 * filename are the same, we assume they're
+			 * the same image and don't update.
+			 */
 			if ( $existing_filename === $image_filename ) {
 				$this->media_exists++;
 				return false;

--- a/importers/class-ucf-location-importer.php
+++ b/importers/class-ucf-location-importer.php
@@ -532,6 +532,26 @@ Errors:
 		 * @return bool True if file is successfully uploaded and attached
 		 */
 		private function upload_media( $image_url, $post_id ) {
+			$existing_thumbnail = get_the_post_thumbnail_url( $post_id );
+
+			$image_filename = '';
+			$existing_filename = '';
+
+			if ( $existing_thumbnail ) {
+				$parts = parse_url( $existing_thumbnail );
+				$existing_filename = isset( $parts['path'] ) ? basename( $parts['path'] ) : '';
+			}
+
+			if ( $image_url ) {
+				$parts = parse_url( $image_url );
+				$image_filename = isset( $parts['path'] ) ? basename( $parts['path'] ) : '';
+			}
+
+			if ( $existing_filename === $image_filename ) {
+				$this->media_exists++;
+				return false;
+			}
+
 			$response = wp_remote_get( $image_url, array( 'timeout' => 15 ) );
 			$filename   = basename( $image_url );
 


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Location-CPT-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Location-CPT-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds an additional logical check to ensure the same files don't get uploaded every month during the locations import. At this point, we're just checking to see if the existing filename and the incoming filename are different.

**Motivation and Context**
Kim is tired of the same 150 images getting imported over and over again on the main site. Also, it's probably a waste of hard drive space.

**How Has This Been Tested?**
The import has been run in develop.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
