### PR TITLE
Script enqueuing improvements

### DIFF
--- a/includes/class-ucf-location-common.php
+++ b/includes/class-ucf-location-common.php
@@ -5,56 +5,38 @@
 if ( ! class_exists( 'UCF_Location_Common' ) ) {
 	class UCF_Location_Common {
 		/**
-		 * Enqueues all front end assets.
-		 * @author Jim Barnes
-		 * @since 0.1.0
+		 * Registers frontend assets for the location typeahead shortcode.
+		 * @author Jo Dickson
+		 * @since 0.3.1
 		 * @return void
 		 */
-		public static function enqueue_frontend_assets() {
-			$ds_typeahead_enqueued = wp_script_is( 'ucf-degree-typeahead-js' );
-
+		public static function register_frontend_assets() {
 			$deps_array = array(
 				'jquery'
 			);
 
 			if ( UCF_Location_Config::get_option_or_default( 'typeahead_js_enqueue' ) ) {
-				if ( ! $ds_typeahead_enqueued ) {
-					wp_enqueue_script(
-						'typeahead-js',
-						UCF_LOCATION__TYPEAHEAD,
-						null,
-						null,
-						true
-					);
+				wp_register_script(
+					'typeahead-js',
+					UCF_LOCATION__TYPEAHEAD,
+					null,
+					null,
+					true
+				);
 
-					$deps_array[] = 'typeahead-js';
-				}
+				$deps_array[] = 'typeahead-js';
 			}
 
 			if ( UCF_Location_Config::get_option_or_default( 'handlebars_js_enqueue' ) ) {
-				if ( ! $ds_typeahead_enqueued ) {
-					wp_enqueue_script(
-						'handlebars-js',
-						UCF_LOCATION__HANDLEBARS,
-						null,
-						null,
-						true
-					);
+				wp_register_script(
+					'handlebars-js',
+					UCF_LOCATION__HANDLEBARS,
+					null,
+					null,
+					true
+				);
 
-					$deps_array[] = 'handlebars-js';
-				}
-			}
-
-			if ( $ds_typeahead_enqueued ) {
-				/**
-				 * Make sure the dependency array has the degree
-				 * search handles for typeahead and halendars.
-				 * TODO: Update these values after this issue
-				 * has been solved:
-				 * https://github.com/UCF/UCF-Degree-Search-Plugin/issues/83
-				 */
-				$deps_array[] = 'ucf-degree-typeahead-js';
-				$deps_array[] = 'ucf-degree-handlebars-js';
+				$deps_array[] = 'handlebars-js';
 			}
 
 			wp_register_script(
@@ -74,12 +56,20 @@ if ( ! class_exists( 'UCF_Location_Common' ) ) {
 				'UCF_LOCATIONS_SEARCH',
 				$localization_array
 			);
+		}
 
+		/**
+		 * Enqueues frontend assets for the location typeahead shortcode.
+		 * @author Jim Barnes
+		 * @since 0.1.0
+		 * @return void
+		 */
+		public static function enqueue_frontend_assets() {
 			wp_enqueue_script( 'ucf_location_script' );
 		}
 
 		/**
-		 * Gets a sinple of array of locations
+		 * Gets a simple of array of locations
 		 * for the typeahead localization array.
 		 * @author Jim Barnes
 		 * @since 0.1.0

--- a/shortcodes/class-ucf-location-typeahead-sc.php
+++ b/shortcodes/class-ucf-location-typeahead-sc.php
@@ -16,6 +16,7 @@ if ( ! class_exists( 'UCF_Location_Typeahead_Shortcode' ) ) {
 		}
 
 		public static function callback( $atts, $content='' ) {
+			UCF_Location_Common::enqueue_frontend_assets();
 			ob_start();
 		?>
 			<input type="text" class="location-search form-control form-control-lg form-control-search" placeholder="Library" aria-label="Search UCF Locations">

--- a/ucf-location-cpt.php
+++ b/ucf-location-cpt.php
@@ -95,7 +95,7 @@ if ( ! function_exists( 'ucf_location_init' ) ) {
 		add_action( 'init', array( 'UCF_Location_Typeahead_Shortcode', 'register_shortcode' ), 10, 0 );
 		add_action( 'init', array( 'UCF_Location_Search_Shortcode', 'register_shortcode' ), 10, 0 );
 
-		add_action( 'wp_enqueue_scripts', array( 'UCF_Location_Common', 'enqueue_frontend_assets' ), 10, 0 );
+		add_action( 'wp_enqueue_scripts', array( 'UCF_Location_Common', 'register_frontend_assets' ), 10, 0 );
 
 		if ( UCF_Location_Utils::acf_is_active() ) {
 			add_action( 'acf/init', array( 'UCF_Location_Post_Type', 'register_acf_fields' ), 10, 0 );


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Location-CPT-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Location-CPT-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Updated JS for the locations typeahead shortcode to only enqueue on pages that use that shortcode.
- Renamed handles for third-party JS to establish consistency between other UCF plugins that use equivalent scripts and allow a single set of scripts to be used.  This update removes checks for existing scripts from the Degree Search Plugin.

See also: https://github.com/UCF/UCF-Degree-Search-Plugin/pull/90

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To improve performance by eliminating unnecessary scripts on pages that don't require location search features.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
