### PR TITLE
Location Importer Fix - Let's fix that duplicate post_name

### DIFF
--- a/importers/class-ucf-location-importer.php
+++ b/importers/class-ucf-location-importer.php
@@ -287,7 +287,7 @@ Errors:
 			$desc  = isset( $data->profile ) ? trim( $data->profile ) : $data->description;
 
 			$split = explode( '/', untrailingslashit( $data->profile_link ) );
-			$post_name = $this->clean_post_name( end( $split ), $data );
+			$post_name = end( $split );
 
 			$post_data = array(
 				'ID'           => $post_id,


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Location-CPT-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Location-CPT-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Updated import to deal with a bug where the `post_name` of certain locations - *cough* *cough* Barbara Ying Center - would end up duplicating, causing `location-name` and `location-name-2` URLs. This is due to the abbreviation being stripped from the profile link. While is might make sense to take that additional step when creating a location for the first time - in order to mimic the same logic being use on UCF/Campus-Map - on subsequent imports, we can probably just rely on whatever the URL is that is set in the `profile_link` field of the incoming JSON.

**Motivation and Context**
Most importantly, we want the `profile_link` and the actual URL on the main site to match. This will ensure that's the case.

**How Has This Been Tested?**
Changes are available in QA for review.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
