### PR TITLE
Updated both importers to support the new data source from the search…

### DIFF
--- a/importers/class-ucf-location-importer.php
+++ b/importers/class-ucf-location-importer.php
@@ -67,29 +67,26 @@ if ( ! class_exists( 'UCF_Location_Importer' ) ) {
 			 */
 			$upload_dir = '',
 			/**
-			 * @var string The media base of uploaded files on map.ucf.edu
+			 * @var string|null Filters results to a specific data source
 			 */
-			$media_base = '';
+			$data_source = null;
 
 		/**
 		 * Constructs a new instance of the
 		 * UCF_Location_Importer
 		 * @author Jim Barnes
 		 * @since 0.1.0
-		 * @param string $endpoint The URL of the map data to be imported
+		 * @param string $endpoint The URL of the search service locations endpoint
+		 * @param bool $use_progress Whether a progress bar should be displayed
+		 * @param array $desired_object_types Object types to import; empty array imports all types
+		 * @param string|null $data_source Filters results to a specific data source value; null imports all
 		 */
-		public function __construct( $endpoint, $use_progress = true, $desired_object_types = array(), $media_base=null ) {
+		public function __construct( $endpoint, $use_progress = true, $desired_object_types = array(), $data_source = null ) {
 			$this->endpoint = $endpoint;
 			$this->use_progress = $use_progress;
-			$this->desired_object_types = ! empty( $desired_object_types )
-											? $desired_object_types
-											: array(
-												'building',
-												'dininglocation',
-												'location'
-											);
+			$this->desired_object_types = $desired_object_types;
+			$this->data_source = $data_source;
 			$this->upload_dir = wp_upload_dir();
-			$this->media_base = trailingslashit( $media_base );
 		}
 
 		/**
@@ -150,23 +147,40 @@ Errors:
 		}
 
 		/**
-		 * Gets the map data and filters it
+		 * Gets the location data from the search service and filters it.
+		 * Follows pagination to retrieve all results.
 		 * @author Jim Barnes
 		 * @since 0.1.0
 		 * @return void
 		 */
 		private function get_data() {
-			$response      = wp_remote_get( $this->endpoint, array( 'timeout' => 10 ) );
-			$response_code = wp_remote_retrieve_response_code( $response );
-			$result        = array();
+			$url = $this->endpoint;
 
-			if ( is_array( $response ) && is_int( $response_code ) && $response_code < 400 ) {
-				$result = json_decode( wp_remote_retrieve_body( $response ) );
-				// Filter the results before returning.
-				$result = $this->filter_data( $result );
+			if ( ! empty( $this->data_source ) ) {
+				$url = add_query_arg( 'data_source', rawurlencode( $this->data_source ), $url );
 			}
 
-			$this->map_data = $result;
+			$result = array();
+
+			while ( $url ) {
+				$response      = wp_remote_get( $url, array( 'timeout' => 10 ) );
+				$response_code = wp_remote_retrieve_response_code( $response );
+
+				if ( is_wp_error( $response ) || ! is_int( $response_code ) || $response_code >= 400 ) {
+					break;
+				}
+
+				$body = json_decode( wp_remote_retrieve_body( $response ) );
+
+				if ( ! isset( $body->results ) ) {
+					break;
+				}
+
+				$result = array_merge( $result, $body->results );
+				$url    = isset( $body->next ) ? $body->next : null;
+			}
+
+			$this->map_data = $this->filter_data( $result );
 		}
 
 		/**
@@ -195,17 +209,23 @@ Errors:
 		/**
 		 * Filters the returned data to include
 		 * only the desired object types.
+		 * If desired_object_types is empty, all results are returned.
 		 * @author Jim Barnes
 		 * @since 0.1.0
 		 * @param array $results The results to filter
 		 * @return array
 		 */
 		private function filter_data( $results ) {
-			$retval = array();
+			if ( empty( $this->desired_object_types ) ) {
+				return $results;
+			}
+
+			$retval         = array();
+			$desired_lower  = array_map( 'strtolower', $this->desired_object_types );
 
 			foreach( $results as $result ) {
 				// If this isn't an object type we want, skip it!
-				if ( ! in_array( strtolower( $result->object_type ), array_map( 'strtolower', $this->desired_object_types ) ) ) continue;
+				if ( ! in_array( strtolower( $result->object_type ), $desired_lower ) ) continue;
 
 				$retval[] = $result;
 			}
@@ -284,10 +304,8 @@ Errors:
 				return new WP_Error( 'ucflocation_map_location_nameless', 'Map location has no name.' );
 			}
 
-			$desc  = isset( $data->profile ) ? trim( $data->profile ) : $data->description;
-
-			$split = explode( '/', untrailingslashit( $data->profile_link ) );
-			$post_name = end( $split );
+			$desc      = isset( $data->description ) ? trim( $data->description ) : '';
+			$post_name = sanitize_title( $title );
 
 			$post_data = array(
 				'ID'           => $post_id,
@@ -331,9 +349,8 @@ Errors:
 				return new WP_Error( 'ucflocation_map_location_nameless', 'Map location has no name.' );
 			}
 
-			$desc  = isset( $data->profile ) ? trim( $data->profile ) : $data->description;
-			$split = explode( '/', untrailingslashit( $data->profile_link ) );
-			$post_name = $this->clean_post_name( end( $split ), $data );
+			$desc      = isset( $data->description ) ? trim( $data->description ) : '';
+			$post_name = sanitize_title( $title );
 
 			$post_data = array(
 				'post_name'    => $post_name,
@@ -358,24 +375,6 @@ Errors:
 		}
 
 		/**
-		 * Removes the location abbreviation from the
-		 * post_name if it is there.
-		 * @author Jim Barnes
-		 * @since 0.1.0
-		 * @param string $post_name The post name
-		 * @param object $data The location object
-		 */
-		private function clean_post_name( $post_name, $data ) {
-			if ( ! isset( $data->abbreviation ) ) return $post_name;
-
-			$abbr = strtolower( $data->abbreviation );
-			$pattern = "/\-$abbr$/";
-			$post_name = preg_replace( $pattern, '', $post_name );
-
-			return $post_name;
-		}
-
-		/**
 		 * Updates post meta for a location
 		 * @author Jim Barnes
 		 * @since 0.1.0
@@ -395,24 +394,11 @@ Errors:
 				'ucf_location_lng' => $data->googlemap_point[1]
 			), $post_id );
 
-			if ( isset( $data->address ) ) {
-				update_field( 'ucf_location_address', $data->address, $post_id );
-			}
-
 			if ( isset( $data->image ) && ! empty( $data->image ) ) {
-				$result = $this->upload_media(
-					$this->media_base . $data->image,
-					$post_id
-				);
+				$result = $this->upload_media( $data->image, $post_id );
 
 				if ( $result ) {
 					$this->media_locations++;
-				}
-			}
-
-			if ( isset( $data->orgs ) ) {
-				if ( count( $data->orgs->results ) > 0 ) {
-					$this->update_orgs( $post_id, $data->orgs->results );
 				}
 			}
 
@@ -449,54 +435,6 @@ Errors:
 		}
 
 		/**
-		 * Adds orgs data to the location
-		 * @author Jim Barnes
-		 * @since 0.1.0
-		 * @param int $post_id The post ID
-		 * @param array $orgs The array of org data
-		 * @return void
-		 */
-		private function update_orgs( $post_id, $orgs ) {
-			// Start fresh with every import
-			$data = array();
-
-			foreach( $orgs as $org ) {
-				$org_name = $org->name;
-				$org_phone = isset( $org->phone ) ? $org->phone : null;
-				$org_room = isset( $org->room ) ? $org->room : null;
-
-				$org_data = array(
-					'org_name'        => $org_name,
-					'org_phone'       => $org_phone,
-					'org_room'        => $org_room,
-					'org_departments' => array()
-				);
-
-				if ( isset( $org->departments ) && count( $org->departments ) > 0 ) {
-					foreach( $org->departments as $dept ) {
-						$dept_name  = $dept->name;
-						$dept_phone = isset( $dept->phone ) ? $dept->phone : null;
-						$dept_build = isset( $dept->bldg->name ) ? $dept->bldg->name : null;
-						$dept_room  = isset( $dept->room ) ? $dept->room : null;
-
-						$dept_data = array(
-							'dept_name'     => $dept_name,
-							'dept_phone'    => $dept_phone,
-							'dept_building' => $dept_build,
-							'dept_room'     => $dept_room
-						);
-
-						$org_data['org_departments'][] = $dept_data;
-					}
-				}
-
-				$data[] = $org_data;
-			}
-
-			update_field( 'ucf_location_orgs', $data, $post_id );
-		}
-
-		/**
 		 * Removes any existing locations not found
 		 * in the imported data.
 		 * @author Jim Barnes
@@ -505,6 +443,12 @@ Errors:
 		 */
 		private function remove_stale_locations() {
 			foreach( $this->existing_locations as $location ) {
+				// Skip posts of the "location" type — these are manually-managed
+				// campus records that are not present in the imported source data.
+				if ( has_term( 'location', 'location_type', $location->ID ) ) {
+					continue;
+				}
+
 				wp_delete_post( $location->ID, true );
 				$this->removed_locations++;
 			}

--- a/importers/class-ucf-location-importer.php
+++ b/importers/class-ucf-location-importer.php
@@ -157,7 +157,7 @@ Errors:
 			$url = $this->endpoint;
 
 			if ( ! empty( $this->data_source ) ) {
-				$url = add_query_arg( 'data_source', rawurlencode( $this->data_source ), $url );
+				$url = add_query_arg( 'data_source', $this->data_source, $url );
 			}
 
 			$result = array();

--- a/importers/class-ucf-location-importer.php
+++ b/importers/class-ucf-location-importer.php
@@ -76,6 +76,9 @@ if ( ! class_exists( 'UCF_Location_Importer' ) ) {
 		 * UCF_Location_Importer
 		 * @author Jim Barnes
 		 * @since 0.1.0
+		 * @since 0.4.0 Breaking change: the `$media_base` parameter was replaced with `$data_source`.
+		 *              An empty `$desired_object_types` now imports all object types; previously
+		 *              it defaulted to importing only 'building', 'dininglocation', and 'location' types.
 		 * @param string $endpoint The URL of the search service locations endpoint
 		 * @param bool $use_progress Whether a progress bar should be displayed
 		 * @param array $desired_object_types Object types to import; empty array imports all types
@@ -151,6 +154,8 @@ Errors:
 		 * Follows pagination to retrieve all results.
 		 * @author Jim Barnes
 		 * @since 0.1.0
+		 * @since 0.4.0 Breaking change: now throws an `Exception` on HTTP failure or unexpected
+		 *              response shape; previously failed silently with an empty result set.
 		 * @return void
 		 */
 		private function get_data() {
@@ -216,6 +221,8 @@ Errors:
 		 * If desired_object_types is empty, all results are returned.
 		 * @author Jim Barnes
 		 * @since 0.1.0
+		 * @since 0.4.0 Breaking change: an empty `$desired_object_types` now returns all results;
+		 *              previously returned an empty array.
 		 * @param array $results The results to filter
 		 * @return array
 		 */
@@ -293,6 +300,9 @@ Errors:
 		 * Updates an existing post with data from the import
 		 * @author Jim Barnes
 		 * @since 0.1.0
+		 * @since 0.4.0 Breaking change: post description is now sourced from `$data->description`
+		 *              instead of `$data->profile`; post slug is now derived via `sanitize_title()`
+		 *              from the location name instead of from `$data->profile_link`.
 		 * @param int $_id The post ID to update
 		 * @param string $data_id The map ID
 		 * @return bool|WP_Error True if updated, the WP_Error if there was an error
@@ -339,6 +349,9 @@ Errors:
 		 * Creates a new post with data from the import
 		 * @author Jim Barnes
 		 * @since 0.1.0
+		 * @since 0.4.0 Breaking change: post description is now sourced from `$data->description`
+		 *              instead of `$data->profile`; post slug is now derived via `sanitize_title()`
+		 *              from the location name instead of from `$data->profile_link`.
 		 * @param string $data_id The map ID
 		 * @return bool|WP_Error True if created, a WP_Error if there was an error
 		 */
@@ -382,6 +395,9 @@ Errors:
 		 * Updates post meta for a location
 		 * @author Jim Barnes
 		 * @since 0.1.0
+		 * @since 0.4.0 Breaking change: no longer updates `ucf_location_address` or imports org
+		 *              associations; `$data->image` is now expected to be an absolute URL rather
+		 *              than a path relative to `$media_base`.
 		 * @param int $_id The post ID to update
 		 * @param string $data_id The map ID
 		 * @return bool True if updated

--- a/importers/class-ucf-location-importer.php
+++ b/importers/class-ucf-location-importer.php
@@ -166,14 +166,18 @@ Errors:
 				$response      = wp_remote_get( $url, array( 'timeout' => 10 ) );
 				$response_code = wp_remote_retrieve_response_code( $response );
 
-				if ( is_wp_error( $response ) || ! is_int( $response_code ) || $response_code >= 400 ) {
-					break;
+				if ( is_wp_error( $response ) ) {
+					throw new Exception( 'HTTP request failed: ' . $response->get_error_message() );
+				}
+
+				if ( ! is_int( $response_code ) || $response_code >= 400 ) {
+					throw new Exception( "Unexpected HTTP response code $response_code from $url. Aborting import to prevent data loss." );
 				}
 
 				$body = json_decode( wp_remote_retrieve_body( $response ) );
 
 				if ( ! isset( $body->results ) ) {
-					break;
+					throw new Exception( "Unexpected response shape from $url: missing 'results' key. Aborting import to prevent data loss." );
 				}
 
 				$result = array_merge( $result, $body->results );

--- a/importers/class-ucf-location-importer.php
+++ b/importers/class-ucf-location-importer.php
@@ -419,20 +419,27 @@ Errors:
 		 */
 		private function update_terms( $post_id, $data ) {
 			$object_type = $data->object_type;
+			$slug        = sanitize_title( $object_type );
+			$term_id     = null;
 
-			$term = null;
+			$existing = term_exists( $slug, 'location_type' );
 
-			if ( term_exists( $object_type, 'location_type' ) ) {
-				$term = get_term_by( 'slug', sanitize_title( $object_type ), 'location_type' );
-				$term = $term->term_id;
+			if ( $existing ) {
+				$term_id = (int) $existing['term_id'];
 			} else {
-				$term = wp_insert_term( $object_type, 'location_type' );
+				$inserted = wp_insert_term( $object_type, 'location_type', array( 'slug' => $slug ) );
+
+				if ( is_wp_error( $inserted ) ) {
+					return;
+				}
+
+				$term_id = (int) $inserted['term_id'];
 				$this->location_types_created++;
 			}
 
 			wp_set_post_terms(
 				$post_id,
-				array( $term ),
+				array( $term_id ),
 				'location_type',
 				false
 			);

--- a/includes/class-ucf-location-wp-cli.php
+++ b/includes/class-ucf-location-wp-cli.php
@@ -50,7 +50,7 @@ if ( ! class_exists( 'UCF_Location_Commands' ) ) {
 										? filter_var( $assoc_args['use-progress'], FILTER_VALIDATE_BOOLEAN )
 										: true;
 			$desired_object_types = ( isset( $assoc_args['object-types'] ) && ! empty( $assoc_args['object-types'] ) )
-										? explode( ',', $assoc_args['object-types'] )
+										? array_values( array_filter( array_map( 'trim', explode( ',', $assoc_args['object-types'] ) ) ) )
 										: array();
 			$data_source          = ( isset( $assoc_args['data-source'] ) && ! empty( $assoc_args['data-source'] ) )
 									? $assoc_args['data-source']

--- a/includes/class-ucf-location-wp-cli.php
+++ b/includes/class-ucf-location-wp-cli.php
@@ -5,12 +5,12 @@
 if ( ! class_exists( 'UCF_Location_Commands' ) ) {
 	class UCF_Location_Commands extends WP_CLI_Command {
 		/**
-		 * Imports map data from the map.ucf.edu JSON feed.
+		 * Imports location data from the search service API.
 		 *
 		 * ## OPTIONS
 		 *
 		 * <endpoint>
-		 * : The URL of the map.ucf.edu JSON feed.
+		 * : The URL of the search service locations endpoint.
 		 *
 		 * [--use-progress[=<use_progress>]]
 		 * : Determines if a progress bar is shown while the import runs.
@@ -21,24 +21,26 @@ if ( ! class_exists( 'UCF_Location_Commands' ) ) {
 		 * 	- false
 		 *
 		 * [--object-types=<object-types>]
-		 * : The type of map objects to import.
+		 * : Comma-separated list of object types to import. Leave empty to import all types.
 		 * ---
-		 * default: building,dininglocation,location
+		 * default:
 		 * ---
 		 *
-		 * [--media-base=<media-base>]
-		 * : The base URL of media objects on map.ucf.edu.
+		 * [--data-source=<data-source>]
+		 * : Filters results to those matching this data_source value. Leave empty to import all data sources.
 		 * ---
-		 * default: https://map.ucf.edu/media/
+		 * default:
 		 * ---
 		 *
 		 * ## EXAMPLES
 		 *
-		 * 	wp locations import https://someurl.com/locations.json
+		 * 	wp locations import https://search.cm.ucf.edu/api/v1/locations/
 		 *
-		 * 	wp locations import --use-progress=false
+		 * 	wp locations import https://search.cm.ucf.edu/api/v1/locations/ --use-progress=false
 		 *
-		 * 	wp locations import --media-base=https://someotherurl.com/media/
+		 * 	wp locations import https://search.cm.ucf.edu/api/v1/locations/ --object-types=Building,Dining
+		 *
+		 * 	wp locations import https://search.cm.ucf.edu/api/v1/locations/ --data-source="FBO Buildings Report"
 		 *
 		 * @when after_wp_load
 		 */
@@ -47,20 +49,19 @@ if ( ! class_exists( 'UCF_Location_Commands' ) ) {
 			$use_progress         = isset( $assoc_args['use-progress'] )
 										? filter_var( $assoc_args['use-progress'], FILTER_VALIDATE_BOOLEAN )
 										: true;
-			$desired_object_types = isset( $assoc_args['object-types'] )
+			$desired_object_types = ( isset( $assoc_args['object-types'] ) && ! empty( $assoc_args['object-types'] ) )
 										? explode( ',', $assoc_args['object-types'] )
-										: array( 'building', 'dininglocation', 'location' );
-			$media_base           = isset( $assoc_args['media-base'] )
-										? $assoc_args['media-base']
-										: 'https://map.ucf.edu/media/';
+										: array();
+			$data_source          = ( isset( $assoc_args['data-source'] ) && ! empty( $assoc_args['data-source'] ) )
+									? $assoc_args['data-source']
+									: null;
 
 			if ( empty( $endpoint ) ) {
-				WP_CLI::error( 'A JSON endpoint is required to run the location importer.' );
+				WP_CLI::error( 'A search service endpoint URL is required to run the location importer.' );
 			}
 
-			$importer = new UCF_Location_Importer( $endpoint, $use_progress, $desired_object_types, $media_base );
-
 			try {
+				$importer = new UCF_Location_Importer( $endpoint, $use_progress, $desired_object_types, $data_source );
 				$importer->import();
 				WP_CLI::success( $importer->print_stats() );
 			} catch ( Exception $e ) {
@@ -86,10 +87,10 @@ if ( ! class_exists( 'UCF_Location_Commands' ) ) {
 		 * default: location
 		 * ---
 		 *
-		 * [--child-type=<child-types>]
-		 * : The location type of the children locations
+		 * [--exclude-child-types=<exclude-child-types>]
+		 * : Comma-separated list of location types to exclude from child association. All other types will be included as children.
 		 * ---
-		 * default: building,dininglocation
+		 * default: location
 		 * ---
 		 *
 		 * [--distance=<distance>]
@@ -110,6 +111,8 @@ if ( ! class_exists( 'UCF_Location_Commands' ) ) {
 		 *
 		 * wp locations associate --parent-types=location,campus
 		 *
+		 * wp locations associate --exclude-child-types=location,parking
+		 *
 		 * wp locations associate --multi-assoc
 		 */
 		public function associate( $args, $assoc_args ) {
@@ -121,9 +124,21 @@ if ( ! class_exists( 'UCF_Location_Commands' ) ) {
 							explode( ',', $assoc_args['parent-types'] ) :
 							array( 'location' );
 
-			$child_types  = isset( $assoc_args['child-types'] ) ?
-							explode( ',', $assoc_args['child-types'] ) :
-							array( 'building', 'dininglocation' );
+			$excluded_child_types = isset( $assoc_args['exclude-child-types'] ) ?
+							array_map( 'sanitize_title', explode( ',', $assoc_args['exclude-child-types'] ) ) :
+							array( 'location' );
+
+			$all_child_types = get_terms( array(
+				'taxonomy'   => 'location_type',
+				'hide_empty' => false,
+				'fields'     => 'slugs',
+			) );
+
+			if ( is_wp_error( $all_child_types ) ) {
+				WP_CLI::error( 'Failed to retrieve location types.' );
+			}
+
+			$child_types = array_values( array_diff( $all_child_types, $excluded_child_types ) );
 
 			$distance     = isset( $assoc_args['distance'] ) ?
 							$assoc_args['distance'] :


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Location-CPT-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Location-CPT-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
This PR migrates the location importer to a new data source and adds several improvements to both the import and associate WP-CLI commands:

- **New data source**: Updated the importer to pull from `https://search.cm.ucf.edu/api/v1/locations/` (previously `https://map.ucf.edu/locations.json`). The new API returns paginated results; the importer now follows `next` links until all records are fetched.
- **Field mapping updates**: Adapted the importer to the new API response shape — `description` (was `profile`), full image URLs (no longer relative paths requiring a media base), integer IDs, and title-case `object_type` values. Removed handling for `address` and `orgs` fields not present in the new API.
- **`--data-source` option** (import command): Adds a `data_source` query parameter to the initial API request, allowing imports to be scoped to a specific data source value.
- **Protect manually-managed location records**: `remove_stale_locations()` now skips deletion of any post that has the `location_type` taxonomy term `location`. These records (e.g., campuses) are managed manually and will not appear in the imported source data.
- **`--exclude-child-types` option** (associate command): Replaces the previous `--child-types` include-list flag with an exclude-list flag. At runtime, all `location_type` terms are fetched and the excluded types are subtracted, so new location types are automatically included as children without requiring command changes. Defaults to excluding `location`.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The previous data source (`map.ucf.edu`) is being replaced by the UCF search service API as the canonical source for location data. The new API has a different structure, supports pagination, and introduces data source filtering. Additionally, campus-level records of type `location` are now defined manually in WordPress and must not be removed during automated import runs. The associate command change future-proofs the child type selection so new location types are included automatically.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
- Ran `wp locations import` against the live search service endpoint and verified records were created/updated correctly.
- Confirmed paginated results are fully consumed by checking total imported record counts against the API's `count` value.
- Verified that posts with `location_type` = `location` are not deleted after a fresh import run.
- Ran `wp locations associate` and confirmed that `location`-type posts are excluded from child association by default and that other types are associated correctly.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [x] I have updated the documentation accordingly.